### PR TITLE
fix: Typo in regenerate function and button

### DIFF
--- a/admin/src/pages/HomePage/index.js
+++ b/admin/src/pages/HomePage/index.js
@@ -55,14 +55,14 @@ const HomePage = () => {
     []
   );
 
-  const regenrate = async () => {
+  const regenerate = async () => {
     const { data } = await get(`/strapi-content-type-explorer/get-types`);
     setData(data);
     drawDiagram();
   };
 
   useEffectSkipInitial(() => {
-    regenrate();
+    regenerate();
   }, [options.showAdminTypes, options.showPluginTypes]);
 
   useEffect(() => {
@@ -97,9 +97,9 @@ const HomePage = () => {
           <Button
             variant="secondary"
             startIcon={<Refresh />}
-            onClick={regenrate}
+            onClick={regenerate}
           >
-            Regenrate
+            Regenerate
           </Button>
         }
       />


### PR DESCRIPTION
## What's done?
- [x] Rename function `regenrate` into `regenerate`
- [x] Rename button in UI to "Regenerate"